### PR TITLE
Added cachefilesd to improve performance.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,4 +56,16 @@ unless node[:nfs_exports].nil?
   execute "exportfs -ra" do
     command "exportfs -ra"
   end
+  # add cachefilesd to improve nfs performance
+  package "cachefilesd" do
+    action :install
+  end
+  
+  file "/etc/default/cachefilesd" do
+    content <<-EOS
+  RUN=yes
+    EOS
+    action :create
+    mode 0755
+  end
 end


### PR DESCRIPTION
Recently I updated vampd on my local dev machine and have found nfs to be much slower than before. I found that cachefilesd combined with using git's preloadindex dramatically improved its performance.
